### PR TITLE
-Add support for including Subject Alternative Names (SANs) from

### DIFF
--- a/src/mod/acme/utils.go
+++ b/src/mod/acme/utils.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"strings"
+	"unicode"
 )
 
 // Get the issuer name from pem file
@@ -40,6 +42,8 @@ func ExtractDomains(certBytes []byte) ([]string, error) {
 	return []string{}, errors.New("decode cert bytes failed")
 }
 
+
+
 func ExtractIssuerName(certBytes []byte) (string, error) {
 	// Parse the PEM block
 	block, _ := pem.Decode(certBytes)
@@ -62,6 +66,20 @@ func ExtractIssuerName(certBytes []byte) (string, error) {
 	issuer := cert.Issuer.Organization[0]
 
 	return issuer, nil
+}
+
+// ExtractDomainsFromPEM reads a PEM certificate file and returns all SANs
+func ExtractDomainsFromPEM(pemFilePath string) ([]string, error) {
+
+	certBytes, err := os.ReadFile(pemFilePath)
+	if err != nil {
+			return nil, err
+	}
+	domains,err := ExtractDomains(certBytes)
+	if err != nil {
+		return nil, err
+	}
+	return domains, nil
 }
 
 // Check if a cert is expired by public key
@@ -97,4 +115,53 @@ func CertExpireSoon(certBytes []byte, numberOfDays int) bool {
 		}
 	}
 	return false
+}
+
+
+// NormalizeDomain cleans and validates a domain string.
+// - Trims spaces around the domain
+// - Converts to lowercase
+// - Removes trailing dot (FQDN canonicalization)
+// - Checks that the domain conforms to standard rules:
+//   * Each label ≤ 63 characters
+//   * Only letters, digits, and hyphens
+//   * Labels do not start or end with a hyphen
+//   * Labels must have >= 2 characters
+//   * Full domain ≤ 253 characters
+// Returns an empty string if the domain is invalid.
+func NormalizeDomain(d string) (string, error) {
+	d = strings.TrimSpace(d)
+	d = strings.ToLower(d)
+	d = strings.TrimSuffix(d, ".")
+		
+	if len(d) == 0 {
+		return "", errors.New("domain is empty")
+	}
+	if len(d) > 253 {
+		return "", errors.New("domain exceeds 253 characters")
+	}
+
+	labels := strings.Split(d, ".")
+	for _, label := range labels {
+		if len(label) == 0 {
+			return "", errors.New("Domain '" + d + "' not valid: Empty label")
+		}
+		if len(label) < 2 {
+			return "", errors.New("Domain '" + d + "' not valid: label '" + label + "' is too short")
+		}
+		if len(label) > 63 {
+			return "", errors.New("Domain not valid: label exceeds 63 characters")
+		}
+
+		for i, r := range label {
+			if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-') {
+				return "", errors.New("Domain '" + d + "' not valid: Invalid character '" + string(r) + "' in label")
+			}
+			if (i == 0 || i == len(label)-1) && r == '-' {
+				return "", errors.New("Domain '" + d + "' not valid: label '"+ label +"' starts or ends with hyphen")
+			}
+		}
+	}
+
+	return d, nil
 }


### PR DESCRIPTION
existing certificates during both manual and automatic renewals. -Enhance filtering and normalization of domain names from the UI to ensure only valid domains are included when requesting certificates.